### PR TITLE
Update link of salt-lint to warpnet/salt-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ A :gem: means **really _awesome / useful_**.
 - [Molten](https://github.com/martinhoefling/molten) - Molten is a WebUI for the REST API exposed by Saltstack.
 - [salt-pepper](https://pypi.org/project/salt-pepper/) - A CLI Frontend to the salt-api systems.
 - [salt-sproxy](https://github.com/mirceaulinic/salt-sproxy) - Salt plugin to automate the management and configuration of devices and applications, without running (Proxy) Minions.
-- [salt-lint](https://github.com/roaldnefs/salt-lint/) - Checks Salt state files (SLS) for practices and behavior that could potentially be improved.
+- [salt-lint](https://github.com/warpnet/salt-lint/) - Checks Salt state files (SLS) for practices and behavior that could potentially be improved.
 - [Alcali](https://alcali.dev/) - A web based tool for monitoring and administrating Saltstack Salt.
 
 ## Presentations


### PR DESCRIPTION
Update link of [salt-lint](https://github.com/warpnet/salt-lint) because it has been moved to the Warpnet organization, for more info see: https://github.com/warpnet/salt-lint/issues/61.